### PR TITLE
fix: prevent unnecessary API calls when no Trello cards exist

### DIFF
--- a/BUGFIX.md
+++ b/BUGFIX.md
@@ -1,0 +1,34 @@
+# Bug Fix: Handling Empty Trello Lists
+
+## Issue Description
+
+The application was unnecessarily calling out to external services and generating imaginary content when there were 0 cards in the Trello TODO list to process. This resulted in wasted API calls and potentially confusing output.
+
+## Fix Implementation
+
+The following changes were made to address this issue:
+
+1. Modified `prepare_inputs` method in `src/pro_tools/crew.py` to raise a specific `ValueError` when no cards are found in the TODO list, instead of continuing with empty inputs.
+
+2. Updated the `run` function in `src/pro_tools/main.py` to catch this specific exception and handle it gracefully with a clear message to the user.
+
+3. Added a test case in `src/pro_tools/tests/test_no_cards.py` to verify that the fix correctly handles the case when no cards are found.
+
+## Testing
+
+The fix has been tested by:
+
+1. Unit testing with mocked Trello API responses to simulate an empty list.
+2. Manual testing by running the application with an empty Trello list.
+
+## How to Verify
+
+To verify this fix:
+
+1. Ensure your Trello TODO list is empty.
+2. Run the application using `python -m src.pro_tools.main run`.
+3. The application should exit gracefully with a message indicating that there are no cards to process, without making unnecessary API calls or generating content.
+
+## Additional Notes
+
+This fix improves the efficiency of the application by avoiding unnecessary processing when there's no work to be done, and provides clearer feedback to the user about the state of their Trello board.

--- a/src/pro_tools/crew.py
+++ b/src/pro_tools/crew.py
@@ -75,7 +75,8 @@ class ProTools:
             
         if not cards:
             print("No cards found in the TODO list.")
-            return inputs
+            # Instead of continuing with empty inputs, raise an exception to stop the process
+            raise ValueError("No cards found in the TODO list. Nothing to process.")
             
         inputs["trello_cards"] = cards
         print(f"\nFinal inputs prepared: {inputs}")

--- a/src/pro_tools/main.py
+++ b/src/pro_tools/main.py
@@ -32,6 +32,17 @@ def run():
         crew = pro_tools.crew()
         print("Starting crew execution...")
         crew.kickoff()
+    except ValueError as e:
+        if "No cards found in the TODO list" in str(e):
+            print(f"\nNotice: {str(e)}")
+            print("The application will exit without processing as there are no cards to work on.")
+            sys.exit(0)  # Exit with success code as this is an expected condition
+        else:
+            print(f"\nError during execution: {str(e)}")
+            import traceback
+            print("\nFull error trace:")
+            print(traceback.format_exc())
+            sys.exit(1)
     except Exception as e:
         print(f"\nError during execution: {str(e)}")
         import traceback

--- a/src/pro_tools/tests/__init__.py
+++ b/src/pro_tools/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for pro_tools 

--- a/src/pro_tools/tests/test_no_cards.py
+++ b/src/pro_tools/tests/test_no_cards.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from pro_tools.crew import ProTools
+
+
+class TestNoCardsHandling(unittest.TestCase):
+    """Test the handling of scenarios where no cards are found in the TODO list."""
+
+    @patch('pro_tools.utils.trello_utils.TrelloUtils')
+    def test_no_cards_raises_value_error(self, mock_trello_utils):
+        """Test that a ValueError is raised when no cards are found."""
+        # Setup mock
+        mock_instance = MagicMock()
+        mock_trello_utils.return_value = mock_instance
+        
+        # Mock verify_board_access to return a valid board
+        mock_instance.verify_board_access.return_value = {
+            'lists': [{'id': 'mock_list_id', 'name': 'TODO'}]
+        }
+        
+        # Mock verify_list to return a valid list
+        mock_instance.verify_list.return_value = {'id': 'mock_list_id', 'name': 'TODO'}
+        
+        # Mock get_cards_in_list to return an empty list (no cards)
+        mock_instance.get_cards_in_list.return_value = []
+        
+        # Set environment variables
+        os.environ['TRELLO_BOARD_ID'] = 'mock_board_id'
+        os.environ['TRELLO_TOOD_LIST_ID'] = 'mock_list_id'
+        
+        # Create ProTools instance
+        pro_tools = ProTools()
+        
+        # Test that prepare_inputs raises ValueError when no cards are found
+        with self.assertRaises(ValueError) as context:
+            pro_tools.prepare_inputs({})
+        
+        # Verify the error message
+        self.assertIn("No cards found in the TODO list", str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
# Description

This PR fixes a bug where the application unnecessarily calls out and generates imaginary content when 0 cards exist for processing in the Trello TODO list. The fix properly handles this case by raising a specific exception and exiting gracefully with a clear message to the user.

## Type of Change

version: fix      # Bug fix (patch version bump)

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG